### PR TITLE
Update Dockerfile to Debian base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM python:3.13-slim
+FROM python:3.13
 
 # Set working directory
 WORKDIR /app
 
 # Install build dependencies for opencv
-RUN apk add --no-cache build-base
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        libgl1 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
 COPY requirements.txt ./


### PR DESCRIPTION
## Summary
- use regular `python:3.13` Docker image instead of `slim`
- install required build packages using `apt-get`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6843924ae44483289528b5173815c8f2