### PR TITLE
Fix QR code overlap on mobile

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
                             <button class="text-blue-600" onclick="toggleQr('{{ device.name }}')" title="View QR"><i data-feather="eye"></i></button>
                         </div>
                     </div>
-                    <div id="{{ device.name }}-qr" data-qr="{{ device.qr }}" class="mt-2 hidden w-40 h-40"></div>
+                    <div id="{{ device.name }}-qr" data-qr="{{ device.qr }}" class="mt-2 mb-4 hidden w-64 h-64"></div>
                 </li>
             {% endfor %}
             </ul>


### PR DESCRIPTION
## Summary
- expand QR code container so the QR doesn't overlap other text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843975fef6483288d94d1afc90c7785