### PR TITLE
Implement dark mode that tracks system preference

### DIFF
--- a/templates/add_device.html
+++ b/templates/add_device.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Add Device</title>
+    <script>
+        tailwind.config = { darkMode: 'media' }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/feather-icons"></script>
 </head>
-<body class="bg-gray-100 p-6">
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-6">
     <div class="max-w-xl mx-auto">
         <div class="flex justify-between items-center mb-4">
             <h1 class="text-2xl font-bold">Add New Device</h1>
@@ -26,7 +29,7 @@
             {% endif %}
         {% endwith %}
 
-        <form method="POST" enctype="multipart/form-data" class="bg-white p-4 rounded shadow mb-6">
+        <form method="POST" enctype="multipart/form-data" class="bg-white dark:bg-gray-800 p-4 rounded shadow mb-6">
             <label class="block mb-2">Device Name:</label>
             <input type="text" name="name" class="border p-2 w-full mb-4">
             <label class="block mb-2">Category:</label>

--- a/templates/edit_device.html
+++ b/templates/edit_device.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Edit Device</title>
+    <script>
+        tailwind.config = { darkMode: 'media' }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/feather-icons"></script>
 </head>
-<body class="bg-gray-100 p-6">
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-6">
     <div class="max-w-xl mx-auto">
         <div class="flex justify-between items-center mb-4">
             <h1 class="text-2xl font-bold">Edit Device</h1>
@@ -26,7 +29,7 @@
             {% endif %}
         {% endwith %}
 
-        <form method="POST" class="bg-white p-4 rounded shadow">
+        <form method="POST" class="bg-white dark:bg-gray-800 p-4 rounded shadow">
             <label class="block mb-2">Device Name:</label>
             <input type="text" name="name" value="{{ name }}" class="border p-2 w-full mb-4">
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Smart Home QR Manager</title>
+    <script>
+        tailwind.config = { darkMode: 'media' }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/feather-icons"></script>
 </head>
-<body class="bg-gray-100 p-6">
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-6">
     <div class="max-w-xl mx-auto">
         <div class="flex justify-between items-center mb-4">
             <h1 class="text-2xl font-bold">Smart Home QR Code Manager</h1>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Settings</title>
+    <script>
+        tailwind.config = { darkMode: 'media' }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/feather-icons"></script>
 </head>
-<body class="bg-gray-100 p-6">
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-6">
     <div class="max-w-xl mx-auto">
         <div class="flex justify-between items-center mb-4">
             <h1 class="text-2xl font-bold">Settings</h1>


### PR DESCRIPTION
## Summary
- follow `prefers-color-scheme` for dark mode
- ensure forms and pages use dark-friendly backgrounds

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68439f79b4048328a7bf9c8f52adf504